### PR TITLE
Switch lang to use `es`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -47,6 +47,10 @@ toc-location: left
 number-sections: true
 highlight-style: pygments
 
+# Switch to using Spanish translation
+# https://github.com/quarto-dev/quarto-cli/tree/main/src/resources/language
+lang: es 
+
 format:
   html:
     theme: simplex


### PR DESCRIPTION
Related to the rOpenSci slack question to remove `TOC` title saying "On this page"

https://github.com/quarto-dev/quarto-cli/tree/main/src/resources/language